### PR TITLE
Some Makefile changes/fixes

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -233,3 +233,11 @@ endif
 endif
 
 SOURCES_C += $(LIBRETRO_DIR)/file/retro_stat.c
+
+SOURCES_C += $(CORE_DIR)/pgxp/pgxp_cpu.c \
+				 $(CORE_DIR)/pgxp/pgxp_debug.c \
+				 $(CORE_DIR)/pgxp/pgxp_gpu.c \
+				 $(CORE_DIR)/pgxp/pgxp_gte.c \
+				 $(CORE_DIR)/pgxp/pgxp_main.c \
+				 $(CORE_DIR)/pgxp/pgxp_mem.c \
+				 $(CORE_DIR)/pgxp/pgxp_value.c

--- a/pgxp/pgxp_cpu.c
+++ b/pgxp/pgxp_cpu.c
@@ -1,3 +1,4 @@
+#include <string.h>
 
 #include "pgxp_cpu.h"
 #include "pgxp_value.h"

--- a/pgxp/pgxp_debug.c
+++ b/pgxp/pgxp_debug.c
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include "pgxp_debug.h"
 #include "pgxp_cpu.h"
 #include "pgxp_gte.h"

--- a/pgxp/pgxp_gpu.c
+++ b/pgxp/pgxp_gpu.c
@@ -24,12 +24,12 @@
 *	Created on: 25 Mar 2016
 *      Author: iCatButler
 ***************************************************************************/
-
 #include "pgxp_gpu.h"
 #include "pgxp_mem.h"
 #include "pgxp_value.h"
 
 #include <math.h>
+#include <string.h>
 #include <assert.h>
 
 /////////////////////////////////

--- a/pgxp/pgxp_gte.c
+++ b/pgxp/pgxp_gte.c
@@ -25,6 +25,8 @@
 *      Author: iCatButler
 ***************************************************************************/
 
+#include <string.h>
+
 #include "pgxp_gte.h"
 #include "pgxp_main.h"
 #include "pgxp_value.h"

--- a/pgxp/pgxp_mem.c
+++ b/pgxp/pgxp_mem.c
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include "pgxp_mem.h"
 #include "pgxp_cpu.h"
 #include "pgxp_gte.h"

--- a/pgxp/pgxp_value.c
+++ b/pgxp/pgxp_value.c
@@ -1,3 +1,5 @@
+#include <math.h>
+
 #include "pgxp_value.h"
 #include "limits.h"
 


### PR DESCRIPTION
This allows me to compile it with GCC on Linux.

The current issue I am running into is that as soon as I enable PGXP and set it to memory only and go back to the game, it crashes on a 'floating point exception'.

This is testing Tomb Raider 1 with a savestate.
